### PR TITLE
feat: Add duration time conversion utilities

### DIFF
--- a/DURATION_IMPLEMENTATION.md
+++ b/DURATION_IMPLEMENTATION.md
@@ -1,0 +1,101 @@
+# Duration Time Conversion Implementation
+
+## Summary
+This implementation resolves the feature request for simplified time conversion utilities using `std::chrono`.
+
+## Changes Made
+
+### 1. Created `Duration.ixx` Module
+**Location:** `src/core/Duration.ixx`
+
+**Features:**
+- **Type Alias:** `druid::core::seconds` - A `std::chrono::duration<double>` type for fractional seconds
+  - Essential for physics and math calculations requiring precise fractional time values
+  
+- **Conversion Functions:**
+  - `to_seconds()` - Converts `std::chrono::steady_clock::duration` to fractional seconds
+  - `to_milliseconds()` - Converts to `std::chrono::milliseconds`
+  - `to_microseconds()` - Converts to `std::chrono::microseconds`
+  - `to_nanoseconds()` - Converts to `std::chrono::nanoseconds`
+
+**Design Benefits:**
+- All functions are `constexpr` and `noexcept` for optimal performance
+- Fully documented with Doxygen-style comments
+- Consistent with existing codebase style (using `[[nodiscard]]`, `auto`, etc.)
+
+### 2. Created `Duration.test.cpp` Test Suite
+**Location:** `src/core/test/Duration.test.cpp`
+
+**Test Coverage:**
+- ✅ Type alias functionality and fractional value support
+- ✅ Conversion from various time units to seconds
+- ✅ Conversion between all supported time units
+- ✅ Precision tests for fractional seconds
+- ✅ Edge cases (zero duration, very small values)
+- ✅ Compile-time evaluation (`constexpr` support)
+- ✅ Arithmetic operations with the `seconds` type
+
+**Total Tests:** 14 comprehensive test cases
+
+### 3. Updated Build Configuration
+- ✅ Added `Duration.ixx` to `src/core/CMakeLists.txt`
+- ✅ Added `Duration.test.cpp` to `src/core/test/CMakeLists.txt`
+
+## Usage Examples
+
+```cpp
+#include <chrono>
+import druid.core.duration;
+
+using namespace std::chrono_literals;
+using druid::core::seconds;
+using druid::core::to_seconds;
+
+// Fractional seconds for physics calculations
+seconds deltaTime = to_seconds(16ms);  // 0.016 seconds (60 FPS)
+
+// Convert steady_clock duration to different units
+auto duration = std::chrono::steady_clock::now() - start_time;
+auto ms = to_milliseconds(duration);
+auto us = to_microseconds(duration);
+auto ns = to_nanoseconds(duration);
+
+// Use in calculations
+auto velocity = distance / to_seconds(duration).count();
+```
+
+## Benefits
+
+1. **Cleaner Code:** Eliminates verbose `std::chrono::duration_cast` calls
+2. **Physics-Friendly:** The `seconds` type as `double` is perfect for mathematical calculations
+3. **Type Safety:** Maintains strong typing while simplifying conversions
+4. **Performance:** All functions are `constexpr` and `noexcept`
+5. **Maintainability:** Simple functional approach over class-based solution
+
+## Testing
+
+To build and run the tests:
+
+```bash
+# Configure the project
+cmake --preset <your-preset>
+
+# Build
+cmake --build --preset <your-preset>
+
+# Run tests
+ctest --preset <your-preset>
+```
+
+The Duration tests will be included in the `druid-core-test` executable.
+
+## Files Modified/Created
+
+- ✅ `src/core/Duration.ixx` (new)
+- ✅ `src/core/test/Duration.test.cpp` (new)
+- ✅ `src/core/CMakeLists.txt` (modified)
+- ✅ `src/core/test/CMakeLists.txt` (modified)
+
+---
+
+**Status:** ✅ Feature Complete - Ready for Review

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(${PROJECT_NAME} PUBLIC
 target_sources(${PROJECT_NAME} PUBLIC
     FILE_SET cxx_modules TYPE CXX_MODULES FILES
         Concepts.ixx
+        Duration.ixx
         Engine.ixx
         EnumMask.ixx
         Event.ixx

--- a/src/core/Duration.ixx
+++ b/src/core/Duration.ixx
@@ -1,0 +1,44 @@
+module;
+
+#include <chrono>
+
+export module druid.core.duration;
+
+export namespace druid::core
+{
+	/// @brief Type alias for fractional seconds using double precision.
+	/// This is useful for physics and math calculations that require fractional time values.
+	using seconds = std::chrono::duration<double>;
+
+	/// @brief Convert a steady_clock::duration to fractional seconds.
+	/// @param x The duration to convert.
+	/// @return The duration in seconds as a double-precision floating-point value.
+	[[nodiscard]] constexpr auto to_seconds(std::chrono::steady_clock::duration x) noexcept -> seconds
+	{
+		return std::chrono::duration_cast<seconds>(x);
+	}
+
+	/// @brief Convert a steady_clock::duration to milliseconds.
+	/// @param x The duration to convert.
+	/// @return The duration in milliseconds.
+	[[nodiscard]] constexpr auto to_milliseconds(std::chrono::steady_clock::duration x) noexcept -> std::chrono::milliseconds
+	{
+		return std::chrono::duration_cast<std::chrono::milliseconds>(x);
+	}
+
+	/// @brief Convert a steady_clock::duration to microseconds.
+	/// @param x The duration to convert.
+	/// @return The duration in microseconds.
+	[[nodiscard]] constexpr auto to_microseconds(std::chrono::steady_clock::duration x) noexcept -> std::chrono::microseconds
+	{
+		return std::chrono::duration_cast<std::chrono::microseconds>(x);
+	}
+
+	/// @brief Convert a steady_clock::duration to nanoseconds.
+	/// @param x The duration to convert.
+	/// @return The duration in nanoseconds.
+	[[nodiscard]] constexpr auto to_nanoseconds(std::chrono::steady_clock::duration x) noexcept -> std::chrono::nanoseconds
+	{
+		return std::chrono::duration_cast<std::chrono::nanoseconds>(x);
+	}
+}

--- a/src/core/test/CMakeLists.txt
+++ b/src/core/test/CMakeLists.txt
@@ -3,6 +3,7 @@ project(druid-core-test)
 project_add_executable(${PROJECT_NAME})
 
 target_sources(${PROJECT_NAME} PRIVATE
+    Duration.test.cpp
     Engine.test.cpp
     Object.test.cpp
     EnumMask.test.cpp

--- a/src/core/test/Duration.test.cpp
+++ b/src/core/test/Duration.test.cpp
@@ -1,0 +1,137 @@
+#include <gtest/gtest.h>
+#include <chrono>
+
+import druid.core.duration;
+
+using namespace std::chrono_literals;
+using druid::core::seconds;
+using druid::core::to_seconds;
+using druid::core::to_milliseconds;
+using druid::core::to_microseconds;
+using druid::core::to_nanoseconds;
+
+TEST(Duration, seconds_type_alias)
+{
+	// Test that seconds type can hold fractional values
+	seconds s{1.5};
+	EXPECT_DOUBLE_EQ(s.count(), 1.5);
+
+	seconds s2{0.001};
+	EXPECT_DOUBLE_EQ(s2.count(), 0.001);
+}
+
+TEST(Duration, to_seconds_from_milliseconds)
+{
+	auto duration = 1500ms;
+	auto result = to_seconds(duration);
+	EXPECT_DOUBLE_EQ(result.count(), 1.5);
+}
+
+TEST(Duration, to_seconds_from_microseconds)
+{
+	auto duration = 2500000us;
+	auto result = to_seconds(duration);
+	EXPECT_DOUBLE_EQ(result.count(), 2.5);
+}
+
+TEST(Duration, to_seconds_from_nanoseconds)
+{
+	auto duration = 3500000000ns;
+	auto result = to_seconds(duration);
+	EXPECT_DOUBLE_EQ(result.count(), 3.5);
+}
+
+TEST(Duration, to_milliseconds_from_seconds)
+{
+	auto duration = std::chrono::seconds{2};
+	auto result = to_milliseconds(duration);
+	EXPECT_EQ(result.count(), 2000);
+}
+
+TEST(Duration, to_milliseconds_from_microseconds)
+{
+	auto duration = 5000us;
+	auto result = to_milliseconds(duration);
+	EXPECT_EQ(result.count(), 5);
+}
+
+TEST(Duration, to_microseconds_from_milliseconds)
+{
+	auto duration = 3ms;
+	auto result = to_microseconds(duration);
+	EXPECT_EQ(result.count(), 3000);
+}
+
+TEST(Duration, to_microseconds_from_nanoseconds)
+{
+	auto duration = 4000ns;
+	auto result = to_microseconds(duration);
+	EXPECT_EQ(result.count(), 4);
+}
+
+TEST(Duration, to_nanoseconds_from_microseconds)
+{
+	auto duration = 7us;
+	auto result = to_nanoseconds(duration);
+	EXPECT_EQ(result.count(), 7000);
+}
+
+TEST(Duration, to_nanoseconds_from_milliseconds)
+{
+	auto duration = 2ms;
+	auto result = to_nanoseconds(duration);
+	EXPECT_EQ(result.count(), 2000000);
+}
+
+TEST(Duration, precision_test_fractional_seconds)
+{
+	// Test conversion from milliseconds to fractional seconds
+	auto duration = 123ms;
+	auto result = to_seconds(duration);
+	EXPECT_DOUBLE_EQ(result.count(), 0.123);
+}
+
+TEST(Duration, precision_test_small_values)
+{
+	// Test very small duration values
+	auto duration = 1ns;
+	auto result = to_seconds(duration);
+	EXPECT_GT(result.count(), 0.0);
+}
+
+TEST(Duration, zero_duration)
+{
+	// Test zero duration conversion
+	auto duration = std::chrono::steady_clock::duration::zero();
+	
+	EXPECT_DOUBLE_EQ(to_seconds(duration).count(), 0.0);
+	EXPECT_EQ(to_milliseconds(duration).count(), 0);
+	EXPECT_EQ(to_microseconds(duration).count(), 0);
+	EXPECT_EQ(to_nanoseconds(duration).count(), 0);
+}
+
+TEST(Duration, constexpr_evaluation)
+{
+	// Test that functions can be evaluated at compile time
+	constexpr auto duration = std::chrono::milliseconds{1000};
+	constexpr auto result_ms = to_milliseconds(duration);
+	constexpr auto result_us = to_microseconds(duration);
+	constexpr auto result_ns = to_nanoseconds(duration);
+	
+	static_assert(result_ms.count() == 1000);
+	static_assert(result_us.count() == 1000000);
+	static_assert(result_ns.count() == 1000000000);
+}
+
+TEST(Duration, arithmetic_with_seconds_type)
+{
+	// Test that the seconds type works with arithmetic operations
+	seconds s1{1.5};
+	seconds s2{2.5};
+	
+	auto sum = s1 + s2;
+	EXPECT_DOUBLE_EQ(sum.count(), 4.0);
+	
+	auto diff = s2 - s1;
+	EXPECT_DOUBLE_EQ(diff.count(), 1.0);
+}


### PR DESCRIPTION
- Add druid::core::seconds type alias for std::chrono::duration<double>
- Implement to_seconds() for fractional second conversion
- Implement to_milliseconds() conversion function
- Implement to_microseconds() conversion function
- Implement to_nanoseconds() conversion function
- Add comprehensive test suite with 14 test cases
- Update CMakeLists.txt to include new module and tests

This implementation simplifies chrono time conversions and provides a double-precision seconds type essential for physics and math calculations.

Resolves: Time conversion verbosity issue
Closes: #[issue-number]