### PR TITLE
feature/add-intellisense-support-for-vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "C_Cpp.default.compileCommands": "${workspaceFolder}/build/compile_commands.json"
 }


### PR DESCRIPTION
Adds IntelliSense support for VS Code on linux machines out of the box. This implementation simply takes advantage of the `compile_commands.json` file that is already generated by CMake.

closes #71 